### PR TITLE
bugfix/resolvables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         junit_version = '5.3.1'
 
         onixlabs_group = 'io.onixlabs'
-        onixlabs_corda_core_release_version = '4.0.2'
+        onixlabs_corda_core_release_version = '4.0.3'
 
         cordapp_platform_version = 11
         cordapp_contract_name = 'ONIXLabs Corda Identity Framework Contract'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 name=onixlabs-corda-identity-framework
 group=io.onixlabs
-version=4.0.2
+version=4.0.3
 onixlabs.development.jarsign.keystore=../lib/onixlabs.development.pkcs12
 onixlabs.development.jarsign.password=5891f47942424d2acbe108691fdb5ba258712fca7e4762be4327241ebf3dbfa3

--- a/onixlabs-corda-identity-framework-contract/src/main/kotlin/io/onixlabs/corda/identityframework/contract/accounts/AccountParty.kt
+++ b/onixlabs-corda-identity-framework-contract/src/main/kotlin/io/onixlabs/corda/identityframework/contract/accounts/AccountParty.kt
@@ -143,11 +143,9 @@ class AccountParty(
         private val accountType: Class<T>
     ) : AbstractSingularResolvable<T>() {
 
-        override val contractStateType: Class<T>
-            get() = accountType
+        override val contractStateType: Class<T> get() = accountType
 
-        @Transient
-        override val criteria = vaultQuery(accountType) {
+        override val criteria get() = vaultQuery(accountType) {
             contractStateTypes(accountType)
             linearIds(accountLinearId)
         }

--- a/onixlabs-corda-identity-framework-contract/src/main/kotlin/io/onixlabs/corda/identityframework/contract/attestations/AttestationPointer.kt
+++ b/onixlabs-corda-identity-framework-contract/src/main/kotlin/io/onixlabs/corda/identityframework/contract/attestations/AttestationPointer.kt
@@ -131,8 +131,7 @@ class LinearAttestationPointer<T : LinearState> internal constructor(
     constructor(state: T) : this(state.javaClass, state.linearId)
     constructor(stateAndRef: StateAndRef<T>) : this(stateAndRef.state.data)
 
-    @Transient
-    private val criteria: QueryCriteria = vaultQuery(stateType) {
+    private val criteria: QueryCriteria get() = vaultQuery(stateType) {
         stateStatus(Vault.StateStatus.UNCONSUMED)
         relevancyStatus(Vault.RelevancyStatus.ALL)
         linearIds(statePointer)
@@ -215,8 +214,7 @@ class StaticAttestationPointer<T : ContractState> internal constructor(
 
     constructor(stateAndRef: StateAndRef<T>) : this(stateAndRef.state.data.javaClass, stateAndRef.ref)
 
-    @Transient
-    private val criteria: QueryCriteria = vaultQuery(stateType) {
+    private val criteria: QueryCriteria get() = vaultQuery(stateType) {
         stateStatus(Vault.StateStatus.ALL)
         relevancyStatus(Vault.RelevancyStatus.ALL)
         stateRefs(statePointer)

--- a/onixlabs-corda-identity-framework-contract/src/main/kotlin/io/onixlabs/corda/identityframework/contract/claims/ClaimPointer.kt
+++ b/onixlabs-corda-identity-framework-contract/src/main/kotlin/io/onixlabs/corda/identityframework/contract/claims/ClaimPointer.kt
@@ -129,8 +129,7 @@ class LinearClaimPointer<T : CordaClaim<*>> private constructor(
         valueType = claim.value.javaClass
     )
 
-    @Transient
-    private val criteria = vaultQuery(claimType) {
+    private val criteria get() = vaultQuery(claimType) {
         stateStatus(Vault.StateStatus.UNCONSUMED)
         relevancyStatus(Vault.RelevancyStatus.ALL)
         linearIds(value)
@@ -214,8 +213,7 @@ class StaticClaimPointer<T : CordaClaim<*>> private constructor(
         valueType = claim.state.data.value.javaClass
     )
 
-    @Transient
-    private val criteria = vaultQuery(claimType) {
+    private val criteria get() = vaultQuery(claimType) {
         stateStatus(Vault.StateStatus.ALL)
         relevancyStatus(Vault.RelevancyStatus.ALL)
         stateRefs(value)


### PR DESCRIPTION
Replaced `@Transient` annotation with `get()` to criteria fields in resolvable implementations to prevent them being included in serialization.